### PR TITLE
Remove the commas inside structured reference

### DIFF
--- a/Source/ExcelDna.IntelliSense/UIMonitor/FormulaParser.cs
+++ b/Source/ExcelDna.IntelliSense/UIMonitor/FormulaParser.cs
@@ -34,6 +34,9 @@ namespace ExcelDna.IntelliSense
             // the regex below still applies.
             formulaPrefix = Regex.Replace(formulaPrefix, "(\"[^\"]*\")", string.Empty);
 
+            // Remove commas inside structured reference patterns like "Table1[[#All],[Field]]"
+            formulaPrefix = Regex.Replace(formulaPrefix, "(\\[\\[.*?\\])\\s*,", "$1");
+            
             // Remove sub-formulae
             formulaPrefix = Regex.Replace(formulaPrefix, "(\\([^\\(\\)]*\\))| ", string.Empty);
 


### PR DESCRIPTION
Remove the commas inside structured reference patterns like "Table1[[#All],[Field]]"